### PR TITLE
Opsview template uses the correct variables

### DIFF
--- a/templates/check_opsview.cfg.j2
+++ b/templates/check_opsview.cfg.j2
@@ -1,5 +1,5 @@
-{% if nagios_plugins is defined %}
-{% for i in nagios_plugins %}
+{% if opsview_plugins is defined %}
+{% for i in opsview_plugins %}
 command[{{ i.command }}]={{ i.path }} {{ i.arguments }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
The opsview template used to use the nagios variable, changed it to use
specific the opsview variables from default/main.yml
