### PR TITLE
Add option to remove hardcoded checks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,12 @@ opsview_cfg_file: "/usr/local/nagios/etc/nrpe_local/override.cfg"
 nagios_cfg_file: "/etc/nrpe.d/override.cfg"
 nagios_allowed_hosts: "127.0.0.1,10.1.1.1,10.2.2.2"
 
+# Remove all command[*] entries from the default nrpe.cfg file.
+# The "command" settings in the default file take precedence over settings in
+# an nrpe.d directory and can sometimes interfere with how the user actually
+# wants to configure checks.
+remove_hardcoded_checks: false
+
 # If this is True - do not allow command arguments
 nagios_dont_blame: True
 # 

--- a/tasks/nrpe.yml
+++ b/tasks/nrpe.yml
@@ -12,6 +12,15 @@
   notify:
     - "restart nrpe"
 
+- name: Remove all hardcoded command settings from default nrpe.cfg
+  lineinfile:
+    state: absent
+    regexp: '^command\['
+    path: '/etc/nagios/nrpe.cfg'
+  notify:
+    - "restart nrpe"
+  when: remove_hardcoded_checks|default(false)|bool == true
+
 - name: Template in override config file (to set allowed_hosts)
   template: src=override.cfg.j2 dest={{ nagios_cfg_file }} mode=0644
             owner={{ nrpe_user }} group={{ nrpe_group }}

--- a/tasks/opsview.yml
+++ b/tasks/opsview.yml
@@ -7,6 +7,15 @@
   notify:
     - "restart opsview-agent"
 
+- name: Remove all hardcoded command settings from default nrpe.cfg
+  lineinfile:
+    state: absent
+    regexp: '^command\['
+    path: '/usr/local/nagios/etc/nrpe.cfg'
+  notify:
+    - "restart opsview-agent"
+  when: remove_hardcoded_checks|default(false)|bool == true
+
 - name: Template in override config file (to set allowed_hosts)
   template: src=override.cfg.j2 dest={{ opsview_cfg_file }} mode=0644
             owner={{ nrpe_user }} group={{ nrpe_group }}


### PR DESCRIPTION
Sometimes the default checks defined in the default nrpe.cfg file can
interfere with what the user intends to set in an override file. Add an
option that makes it possible to remove any unwanted command[*] settings
from the default nrpe.cfg configuration file. To preserve backwards
compatibility, don't remove hardcoded settings by default. Some setups
may depend on the hardcoded settings being set a certain way.