### PR TITLE
Test nrpe cfg removal of hard coded cehcks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ With EL7 and NRPE changing username that runs nrpe is not trivial and not yet im
 
 With EL6 changing nrpe_user and nrpe_group should work.
 
+https://github.com/CSCfi/ansible-role-nrpe-plugins/ is a sister-role which one can use to actually install plugins.
+
 Requirements
 ------------
 

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -121,6 +121,8 @@ function extra_tests(){
 
     echo "TEST: cat override.cfg"
     cat /etc/nrpe.d/override.cfg
+    echo "TEST: cat resulting nrpe.cfg"
+    cat /etc/nagios/nrpe.cfg
 }
 
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -5,6 +5,6 @@
    vars:
      - nagios_extra_settings_list:
        - some_setting=value
-
+     - remove_hardcoded_checks: True
    roles:
      - ansible-role-nrpe


### PR DESCRIPTION
In testing we now also:
 - print the contents of nrpe.cfg
 - idempotency test (so that the lineinfile of nrpe.cfg doesn't change things every run)