### PR TITLE
Extra settings to nrpe cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ nrpe_extra_rpms:
  - nagios-plugins-smtp
 </pre>
 
+define an include_dir
+<pre>
+nagios_extra_settings_list:
+ - include_dir={{ nagios_include_dir }}
+</pre>
+
 Dependencies
 ------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,9 @@ nagios_debug: False
 nagios_command_timeout: 60
 nagios_connection_timeout: 300
 
+#nagios_extra_settings_list:
+# - include_dir={{ nagios_include_dir }}
+
 opsview_include_dir: "/usr/local/nagios/etc/nrpe_local/"
 nagios_include_dir: "/etc/nrpe.d/"
 

--- a/templates/override.cfg.j2
+++ b/templates/override.cfg.j2
@@ -209,3 +209,9 @@ connection_timeout=300
 # Values: 0=only seed from /dev/[u]random, 1=also seed from weak randomness
 
 #allow_weak_random_seed=1
+
+{% if nagios_extra_settings_list is defined %}
+{% for nagios_extra_c in nagios_extra_settings_list %}
+{{ nagios_extra_c }}
+{% endfor %}
+{% endif %}

--- a/tests/test-in-docker-image.sh
+++ b/tests/test-in-docker-image.sh
@@ -114,12 +114,13 @@ function test_playbook(){
     echo "TEST: ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS}"
     ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} ||(echo "first ansible run failed" && exit 2 )
 
-#    echo "TEST: idempotence test! Same as previous but now grep for changed=0.*failed=0"
-#    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} || grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' ) || (echo 'Idempotence test: fail' && exit 1)
+    echo "TEST: idempotence test! Same as previous but now grep for changed=0.*failed=0"
+    ansible-playbook -i ${ANSIBLE_INVENTORY} ${ANSIBLE_PLAYBOOk} ${ANSIBLE_LOG_LEVEL} --connection=local ${SUDO_OPTION} ${ANSIBLE_EXTRA_VARS} || grep -q 'changed=0.*failed=0' && (echo 'Idempotence test: pass' ) || (echo 'Idempotence test: fail' && exit 1)
 }
 function extra_tests(){
 
-    ${APACHE_CTL} configtest || (echo "php --version was failed" && exit 100 )
+    echo "TEST: cat override.cfg"
+    cat /etc/nrpe.d/override.cfg
 }
 
 
@@ -134,7 +135,7 @@ function main(){
     test_playbook_syntax
     test_playbook
     test_playbook_check
-#    extra_tests
+    extra_tests
 
 }
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -4,7 +4,7 @@
    remote_user: root
    vars:
      - nagios_extra_settings_list:
-       - include_dir={{ nagios_include_dir }}
+       - some_setting=value
 
    roles:
      - ansible-role-nrpe

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -2,5 +2,9 @@
 
  - hosts: localhost
    remote_user: root
+   vars:
+     - nagios_extra_settings_list:
+       - include_dir={{ nagios_include_dir }}
+
    roles:
      - ansible-role-nrpe


### PR DESCRIPTION
Make it possible to add extra values to the override.cfg

It has the include_dir as an example in defaults - if you use this and don't set {{ nagios_cfg_file }} to the /etc/nagios/nrpe.cfg nrpe fails to start (probably because of a loop).