### PR TITLE
reduce confusion around nagios_dont_blame setting

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,8 +32,9 @@ nagios_allowed_hosts: "127.0.0.1,10.1.1.1,10.2.2.2"
 # wants to configure checks.
 remove_hardcoded_checks: false
 
-# If this is True - do not allow command arguments
-nagios_dont_blame: True
+# If nagios_dont_blame is True we allow command arguments
+# Before version 1.3.0 of ansible-role-nrpe setting nagios_dont_blame to True prevented command argments.
+nagios_dont_blame: False
 # 
 nagios_allow_command_sub: False
 

--- a/templates/override.cfg.j2
+++ b/templates/override.cfg.j2
@@ -109,9 +109,9 @@ allowed_hosts=127.0.0.1
 # Values: 0=do not allow arguments, 1=allow command arguments
 
 {% if nagios_dont_blame == true %}
-dont_blame_nrpe=0
-{% else %}
 dont_blame_nrpe=1
+{% else %}
+dont_blame_nrpe=0
 {% endif %}
 
 


### PR DESCRIPTION
With this PR and setting the ansible variable like so:

<pre>
nagios_dont_blame: True
</pre>

now sets the following nagios.cfg setting:

<pre>
dont_blame_nrpe=1
</pre>

(Which allows sending arguments to the checks)

This solves #2

We also change the default to False - so that the default behavior of
this role is the same.

If you(like me) have set nagios_dont_blame: False
you will have to change it to True to keep allowing command arguments.