### PR TITLE
fixing yum

### DIFF
--- a/tasks/nrpe.yml
+++ b/tasks/nrpe.yml
@@ -7,10 +7,11 @@
     - "restart nrpe"
 
 - name: Install extra nrpe packages
-  yum: state=present name={{ item }}
+  yum: 
   with_items: "{{ nrpe_extra_rpms }}"
   notify:
     - "restart nrpe"
+    
 
 - name: Remove all hardcoded command settings from default nrpe.cfg
   lineinfile:

--- a/tasks/nrpe.yml
+++ b/tasks/nrpe.yml
@@ -11,7 +11,6 @@
   with_items: "{{ nrpe_extra_rpms }}"
   notify:
     - "restart nrpe"
-    
 
 - name: Remove all hardcoded command settings from default nrpe.cfg
   lineinfile:


### PR DESCRIPTION
Invoking "yum" only once while using a loop via squash_actions is deprecated. Instead of using a loop to supply multiple items and specifying `name: "{{ item }}"`, please use `name: '{{ nrpe_extra_rpms }}'`
and remove the loop.