### PR TITLE
Adding support for setting SELinux file context

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ additional_nrpe_checks:
       - scripts_name: check_linux_memory
         command: check_linux_memory
         arguments: '-f -w 10 -c 5'
-      - script_name: check_cpu
+      - script_name: check_disk
+        setype: nagios_checkdisk_plugin_exec_t
 </pre>
 
 Adding local nrpe checks with the `additional_nrpe_checks` variabel

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,7 +34,8 @@ remove_hardcoded_checks: false
 
 # If nagios_dont_blame is True we allow command arguments
 # Before version 1.3.0 of ansible-role-nrpe setting nagios_dont_blame to True prevented command argments.
-nagios_default_argument: "{{ nagios_dont_blame | ternary( '$ARG1$', '', '' ) }}"
+nagios_dont_blame: False
+nagios_default_argument: "{{ nagios_dont_blame | ternary( '$ARG1$', '' ) }}"
 
 nagios_allow_command_sub: False
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,7 +34,7 @@ remove_hardcoded_checks: false
 
 # If nagios_dont_blame is True we allow command arguments
 # Before version 1.3.0 of ansible-role-nrpe setting nagios_dont_blame to True prevented command argments.
-nagios_dont_blame: False
+nagios_default_argument: "{{ nagios_dont_blame | ternary( '$ARG1$', '', '' ) }}"
 
 nagios_allow_command_sub: False
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,10 @@
 ---
 # handlers file for ansible-role-nrpe
 #
+ - name: SELinux context changed
+   command: "restorecon {{ item.dest }}"
+   with_items: "{{ additional_nrpe_checks }}"
+
  - name: restart nrpe
    service: name=nrpe state=restarted
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -2,9 +2,11 @@
 # handlers file for ansible-role-nrpe
 #
  - name: SELinux context changed
-   command: "restorecon {{ item.dest }}"
-   with_items: "{{ additional_nrpe_checks }}"
-   when: item.setype is defined
+   command: "restorecon {{ item[0].script_path + item[1].script_name }}"
+   with_subelements:
+     - "{{ additional_nrpe_checks }}"
+     - commands
+   when: item[1].setype is defined
 
  - name: restart nrpe
    service: name=nrpe state=restarted

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,6 +4,7 @@
  - name: SELinux context changed
    command: "restorecon {{ item.dest }}"
    with_items: "{{ additional_nrpe_checks }}"
+   when: item.setype is defined
 
  - name: restart nrpe
    service: name=nrpe state=restarted

--- a/tasks/add_additional_nrpe_checks.yml
+++ b/tasks/add_additional_nrpe_checks.yml
@@ -11,12 +11,13 @@
 
 - name: set SELinux contexts for checks
   sefcontext:
-    target: "{{ item.dest }}"
-    setype: "{{ item.setype }}"
-    state: "{{ item.state }}"
-  with_items: "{{ additional_nrpe_checks }}"
-  when: item.setype is defined
-  nofity: SELinux context changed
+    target: "{{ item[0].script_path + item[1].script_name }}"
+    setype: "{{ item[1].setype }}"
+  with_subelements: 
+    - "{{ additional_nrpe_checks }}"
+    - commands
+  when: item[1].setype is defined
+  notify: SELinux context changed
 
 - name: Genereate facts for additional nrpe checks
   set_fact:

--- a/tasks/add_additional_nrpe_checks.yml
+++ b/tasks/add_additional_nrpe_checks.yml
@@ -9,21 +9,20 @@
   with_items: "{{ additional_nrpe_checks }}"
   when: item.type == 'git'
 
-- name: Set default nrpe command argument when nagios_dont_blame is true
-  set_fact:
-    default_argument: "$ARG1$"
-  when: nagios_dont_blame == true
-- name: Set default nrpe command argument when nagios_dont_blame is false
-  set_fact:
-    default_argument: ""
-  when: nagios_dont_blame == false
+- name: set SELinux contexts for checks
+  sefcontext:
+    target: "{{ item.dest }}"
+    setype: "{{ item.setype }}"
+    state: "{{ item.state }}"
+  with_items: "{{ additional_nrpe_checks }}"
+  nofity: SELinux context changed
 
 - name: Genereate facts for additional nrpe checks
   set_fact:
      nrpe_checks: "{{ nrpe_checks |default([]) + [ {
        'command': item[1].command |default( item[1].script_name ),
        'path': item[0].script_path + item[1].script_name |default( item[1].command ),
-       'arguments': item[1].arguments |default( default_argument )
+       'arguments': item[1].arguments |default( nagios_default_argument )
      }] }}"
   with_subelements:
      - "{{ additional_nrpe_checks }}"

--- a/tasks/add_additional_nrpe_checks.yml
+++ b/tasks/add_additional_nrpe_checks.yml
@@ -15,6 +15,7 @@
     setype: "{{ item.setype }}"
     state: "{{ item.state }}"
   with_items: "{{ additional_nrpe_checks }}"
+  when: item.setype is defined
   nofity: SELinux context changed
 
 - name: Genereate facts for additional nrpe checks


### PR DESCRIPTION
- This is in an effort to make ansible-role-nrpe-plugins redundant.
- Also removed some set_facts in favour of using `ternary()`
- Inspiration is taken from here: https://github.com/CSCfi/ansible-role-nrpe-plugins/blob/master/tasks/main.yml
CSCWOOD-63